### PR TITLE
Version 1.4.5

### DIFF
--- a/currency-per-product-for-woocommerce/currency-per-product-for-woocommerce.php
+++ b/currency-per-product-for-woocommerce/currency-per-product-for-woocommerce.php
@@ -3,13 +3,13 @@
 Plugin Name: Currency per Product for WooCommerce
 Plugin URI: https://www.tychesoftwares.com/store/premium-plugins/currency-per-product-for-woocommerce/
 Description: Set and display prices for WooCommerce products in different currencies.
-Version: 1.4.4
+Version: 1.4.5
 Author: Tyche Softwares
 Author URI: https://www.tychesoftwares.com/
 Text Domain: currency-per-product-for-woocommerce
 Domain Path: /langs
 Copyright: © 2018 Tyche Softwares
-WC tested up to: 3.5.0
+WC tested up to: 3.5.7
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */
@@ -53,7 +53,7 @@ final class Alg_WC_CPP {
 	 * @var   string
 	 * @since 1.0.0
 	 */
-	public $version = '1.4.3';
+	public $version = '1.4.5';
 
 	/**
 	 * @var   Alg_WC_CPP The single instance of the class

--- a/currency-per-product-for-woocommerce/readme.txt
+++ b/currency-per-product-for-woocommerce/readme.txt
@@ -2,8 +2,8 @@
 Contributors: tychesoftwares
 Tags: woocommerce, woo commerce, currency per product, currency, multicurrency
 Requires at least: 4.4
-Tested up to: 5.0
-Stable tag: 1.4.4
+Tested up to: 5.1.1
+Stable tag: 1.4.5
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -62,6 +62,14 @@ There is a number of scenarios that can be implemented with this plugin:
 3. Start by visiting plugin settings at "WooCommerce > Settings > Currency per Product".
 
 == Changelog ==
+
+= 1.4.5 - 25/03/2019 =
+* Fix - Prices for the Bookable products from WooCommerce Bookings plugin were not converted to the default currency when 'Convert to Shop default currency (and set cart and checkout behavior separately)' option is selected for Shop Behaviour setting. This is fixed now. 
+* Fix - The prices for the selected currency for the bookable products were shown as 0 on the Shop page when 'Add original price in shop' option is checked. This is fixed now. 
+* Fix - A fatal error was shown on the Shop page for Variable products when visited as Wholesale customer added from Wholesale Customers For Woo plugin. This is fixed now. 
+
+= 1.4.4 - 16/11/2018 =
+* Version Changed. 
 
 = 1.4.3 - 31/10/2018 =
 * Compatibility with WooCommerce 3.5.0 tested.


### PR DESCRIPTION
Fix - Prices for the Bookable products from WooCommerce Bookings plugin were not converted to the default currency when 'Convert to Shop default currency (and set cart and checkout behavior separately)' option is selected for Shop Behaviour setting. This is fixed now.

Fix - The prices for the selected currency for the bookable products were shown as 0 on the Shop page when 'Add original price in shop' option is checked. This is fixed now.

Fix - A fatal error was shown on the Shop page for Variable products when visited as Wholesale customer added from Wholesale Customers For Woo plugin. This is fixed now.