### PR TITLE
503 service unavailable error fix

### DIFF
--- a/currency-per-product-for-woocommerce/includes/settings/class-alg-wc-cpp-settings-currencies.php
+++ b/currency-per-product-for-woocommerce/includes/settings/class-alg-wc-cpp-settings-currencies.php
@@ -123,14 +123,6 @@ class Alg_WC_CPP_Settings_Currencies extends Alg_WC_CPP_Settings_Section {
 		$total_number = apply_filters( 'alg_wc_cpp', 1, 'value_total_number' );
 		for ( $i = 1; $i <= $total_number; $i++ ) {
 			$currency_to = get_option( 'alg_wc_cpp_currency_' . $i, $currency_from );
-			$custom_attributes = array(
-				'currency_from'        => $currency_from,
-				'currency_to'          => $currency_to,
-				'multiply_by_field_id' => 'alg_wc_cpp_exchange_rate_' . $i,
-			);
-			if ( $currency_from == $currency_to ) {
-				$custom_attributes['disabled'] = 'disabled';
-			}
 			$currencies_settings = array_merge( $currencies_settings, array(
 				array(
 					'title'    => __( 'Currency', 'currency-per-product-for-woocommerce' ) . ' #' . $i . ' [' . $currency_to . ']',


### PR DESCRIPTION
The error occurs due the line of code:

'multiply_by_field_id' => 'alg_wc_cpp_exchange_rate_' . $i,

when used as:

'multiply_by_field_id' => 'alg_wc_cpp_exchange_rate_' . absint($i),

the error is not displayed.
The value of $i = 1 as it's a fresh install and no currencies have been
setup.
The array has been removed as its not being used anywhere. However,
extensive testing is needed to ensure everything works as is.