### PR TITLE
Add apply_filters for get_meta_box_options function result

### DIFF
--- a/currency-per-product-for-woocommerce/includes/settings/class-alg-wc-cpp-metaboxes.php
+++ b/currency-per-product-for-woocommerce/includes/settings/class-alg-wc-cpp-metaboxes.php
@@ -205,7 +205,7 @@ if ( ! class_exists( 'Alg_WC_CPP_Metaboxes' ) ) :
 					'options' => $currency_codes,
 				),
 			);
-			return $options;
+			return apply_filters( 'alg_wc_cpp', $options, 'meta_box_options' );
 		}
 
 	}


### PR DESCRIPTION
Hello, 

I suggest adding apply_filters for the result returned by the get_meta_box_options function in the file currency-per-product-for-woocommerce/includes/settings/class-alg-wc-cpp-metaboxes.php. This will make it possible to sort the $options array.

For example, I had a situation when the main currency in the store is UAH, and the whole price of the goods is in EUR. And since the default currency is UAH, you constantly have to change the currency when adding. And with this change, it will be possible to set a different currency by default.
