### PR TITLE
Currency as per categories and tags were not working.

### DIFF
--- a/currency-per-product-for-woocommerce/includes/class-alg-wc-cpp-core.php
+++ b/currency-per-product-for-woocommerce/includes/class-alg-wc-cpp-core.php
@@ -402,14 +402,15 @@ if ( ! class_exists( 'Alg_WC_CPP_Core' ) ) :
 			$do_check_by_product_cats = ( 'yes' === get_option( 'alg_wc_cpp_by_product_cats_enabled', 'no' ) );
 			$do_check_by_product_tags = ( 'yes' === get_option( 'alg_wc_cpp_by_product_tags_enabled', 'no' ) );
 			if ( $do_check_by_users || $do_check_by_user_roles || $do_check_by_product_cats || $do_check_by_product_tags ) {
+				$product = wc_get_product( $product_id );
 				if ( $do_check_by_users || $do_check_by_user_roles ) {
 					$product_author_id = get_post_field( 'post_author', $product_id );
 				}
 				if ( $do_check_by_product_cats ) {
-					$_product_cats = alg_wc_cpp_get_terms( $product_id, 'product_cat' );
+					$_product_cats = $product->get_category_ids();
 				}
 				if ( $do_check_by_product_tags ) {
-					$_product_tags = alg_wc_cpp_get_terms( $product_id, 'product_tag' );
+					$_product_tags = $product->get_tag_ids();
 				}
 				$total_number = apply_filters( 'alg_wc_cpp', 1, 'value_total_number' );
 				for ( $i = 1; $i <= $total_number; $i++ ) {


### PR DESCRIPTION
Currency as per categories and tags were not working when we select the checkbox in additional option under Currencies page of currency per product categories and currency per product tags.
This issue has been solved in this commit. 
